### PR TITLE
New Hive serde format

### DIFF
--- a/hive/src/main/java/au/com/cba/omnia/ebenezer/scrooge/hive/ParquetTableDescriptor.java
+++ b/hive/src/main/java/au/com/cba/omnia/ebenezer/scrooge/hive/ParquetTableDescriptor.java
@@ -26,13 +26,16 @@ import cascading.tap.hive.HiveTableDescriptor;
  */
 public class ParquetTableDescriptor extends HiveTableDescriptor {
     /** default input format used by Hive */
-    public static final String PARQUET_INPUT_FORMAT      = "parquet.hive.DeprecatedParquetInputFormat";
+    public static final String PARQUET_INPUT_FORMAT      =
+        org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat.class.getName();
 
     /** default output format used by Hive */
-    public static final String PARQUET_OUTPUT_FORMAT     = "parquet.hive.DeprecatedParquetOutputFormat";
+    public static final String PARQUET_OUTPUT_FORMAT     =
+        org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat.class.getName();
 
     /** default serialization lib name*/
-    public static final String PARQUET_SERIALIZATION_LIB = "parquet.hive.serde.ParquetHiveSerDe";
+    public static final String PARQUET_SERIALIZATION_LIB =
+        org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe.class.getName();
 
     /**
      * Constructs a new ParquetHiveTableDescriptor object.

--- a/hive/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/hive/HiveSpec.scala
+++ b/hive/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/hive/HiveSpec.scala
@@ -94,7 +94,7 @@ Hive operations:
   def strict = {
     val x = for {
       _  <- Hive.createParquetTable[SimpleHive]("test", "test", List("part1" -> "string", "part2" -> "string"), None)
-      t1 <- Hive.existsTable("test", "test")
+      t1 <- Hive.existsTableStrict[SimpleHive]("test", "test", List("part1" -> "string", "part2" -> "string"), None)
       t2 <- Hive.existsTableStrict[SimpleHive]("test", "test", List("part1" -> "string"), None)
       t3 <- Hive.existsTableStrict[SimpleHive]("test", "test", List("part1" -> "string", "part2" -> "string"), Some(new Path("/other")))
       t4 <- Hive.existsTableStrict[SimpleHive]("test", "test", List("part1" -> "string", "part2" -> "string"), None, TextFormat())

--- a/hive/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/hive/ParquetTableDescriptorSpec.scala
+++ b/hive/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/hive/ParquetTableDescriptorSpec.scala
@@ -40,11 +40,11 @@ ParquetTableDescriptor
   val sd         = table.getSd
 
   def serial =
-    sd.getSerdeInfo.getSerializationLib === "parquet.hive.serde.ParquetHiveSerDe"
+    sd.getSerdeInfo.getSerializationLib === ParquetTableDescriptor.PARQUET_SERIALIZATION_LIB
 
   def inputFormat =
-    sd.getInputFormat === "parquet.hive.DeprecatedParquetInputFormat"
+    sd.getInputFormat === ParquetTableDescriptor.PARQUET_INPUT_FORMAT
     
   def outputFormat =
-    sd.getOutputFormat === "parquet.hive.DeprecatedParquetOutputFormat"
+    sd.getOutputFormat === ParquetTableDescriptor.PARQUET_OUTPUT_FORMAT
 }

--- a/hive/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/hive/PartitionHiveParquetScroogeSpec.scala
+++ b/hive/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/hive/PartitionHiveParquetScroogeSpec.scala
@@ -49,7 +49,7 @@ Hive support for (thrift scrooge encoded) partitioned parquet tables
   def writeTest = {
     executesOk(write)
 
-    val path = hiveWarehouse </> "database.db" </> "fake_records"
+    val path = hiveWarehouse </> s"$database.db" </> table
 
     facts(
       path ==> exists,
@@ -73,7 +73,7 @@ Hive support for (thrift scrooge encoded) partitioned parquet tables
   def readTest = {
     executesOk(write.flatMap(_ => read))
 
-    val path = hiveWarehouse </> "database.db" </> "some_other_fake_records_table"
+    val path = hiveWarehouse </> s"$database.db" </> "some_other_fake_records_table"
 
 
     facts(

--- a/hive/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/hive/UtilSpec.scala
+++ b/hive/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/hive/UtilSpec.scala
@@ -90,7 +90,7 @@ UtilSpec
   }
 
   def verifyInputOutputFormatForParquet(sd: StorageDescriptor) {
-    sd.getInputFormat() must_== "parquet.hive.DeprecatedParquetInputFormat"
-    sd.getOutputFormat() must_== "parquet.hive.DeprecatedParquetOutputFormat"
+    sd.getInputFormat() must_== ParquetTableDescriptor.PARQUET_INPUT_FORMAT
+    sd.getOutputFormat() must_== ParquetTableDescriptor.PARQUET_OUTPUT_FORMAT
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "0.13.0"
+version in ThisBuild := "0.14.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Upgraded the ParquetTableDescriptor to use the new Hive Parquet Serde classes.

Also added tests to verify the compatibility of the tables created by us and using Hive DDL.

This closes #90.