### PR TITLE
Adding CatAsJson, Small changes in glob to throw the correct exception.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - ci/sbt-setup.sh
 - ci/sbt-setup-version.sh
 script:
-- sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci '; project core; set fork in Test := false; test; project hive; set fork in Test := false; test; project test; set fork in Test := false; test; project all; package; project example; set fork in Test := false; test; assembly; project compat; set fork in Test := false; test; project tools; set fork in Test := false; test; assembly'
+- sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci '; project core; set fork in Test := false; test; project hive; set fork in Test := false; test; project test; set fork in Test := false; test; project all; package; project example; set fork in Test := false; test; assembly; project compat; set fork in Test := false; test; project tools; set fork in Test := false; set parallelExecution in Test := false; test; assembly'
   && ci/sbt-deploy.sh && ci/gh-pages.sh
 after_script:
 - rm -rf ci

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Hadoop
 ```
 hadoop jar ebenezer-assembly-$VERSION.jar au.com.cba.omnia.ebenezer.cli.Cat some/path/x.parquet
 ```
+
+There is another introspection tool which would read the parquet and output as JSON.
+
+```
+hadoop jar ebenezer-assembly-$VERSION.jar au.com.cba.omnia.ebenezer.cli.CatAsJson some/path/x
+.parquet
+```
 This process may take some time as Hadoop unpacks the fat jar prior to running.  Running under
 OS X (or other case-insensitive filesystems) may result in an error relating to a file called
 `META-INF/LICENSE` conflicting with a lower-case file of the same name.  If this occurs, a

--- a/core/src/test/scala/au/com/cba/omnia/ebenezer/test/ThriftArbitraries.scala
+++ b/core/src/test/scala/au/com/cba/omnia/ebenezer/test/ThriftArbitraries.scala
@@ -64,4 +64,14 @@ object ThriftArbitraries {
       address <- arbitrary[Utf8String]
       age <- arbitrary[Int]
     } yield Customer(id.value, name.value, address.value, age))
+
+  implicit def MapishAribiraryLongKey: Arbitrary[Mapish2] =
+    Arbitrary(arbitrary[List[(Long, Utf8String)]] map (ss =>
+      Mapish2(Map(ss.take(10)
+        .map({case (k, v) => (k, v.value)}): _*))))
+
+  implicit def MapishAribiraryListKey: Arbitrary[Mapish3] =
+    Arbitrary(arbitrary[List[(List[Utf8String], Utf8String)]] map (ss =>
+      Mapish3(Map(ss.take(10)
+        .map({case (k, v) => (k.map(_.value), v.value)}): _*))))
 }

--- a/core/src/test/thrift/scrooge/Typed.thrift
+++ b/core/src/test/thrift/scrooge/Typed.thrift
@@ -69,3 +69,11 @@ struct Enumish {
 struct Listish2 {
   1: list<list<string>> values
 }
+
+struct Mapish2 {
+  1: map<i64, string> values
+}
+
+struct Mapish3 {
+  1: map<list<string>, string> values
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -118,11 +118,13 @@ object build extends Build {
         ++ Seq(
           libraryDependencies ++=
             depend.hadoopClasspath ++ depend.hadoop() ++ depend.scalaz() ++ depend.testing() ++ depend.parquet() ++ Seq(
-              noHadoop("com.twitter" % "parquet-tools" % depend.versions.parquet) exclude("org.apache.hadoop", "hadoop-client")
+              noHadoop("com.twitter" % "parquet-tools" % depend.versions.parquet)
+                exclude("org.apache.hadoop", "hadoop-client"),
+              noHadoop("io.argonaut" %% "argonaut"     % "6.1")
             )
         )
   ).dependsOn(core % "test->test")
-
+  
   lazy val example = Project(
     id = "example",
     base = file("example"),

--- a/tools/src/main/scala/au/com/cba/omnia/ebenezer/cli/Cat.scala
+++ b/tools/src/main/scala/au/com/cba/omnia/ebenezer/cli/Cat.scala
@@ -32,5 +32,5 @@ object Cat {
   }
 
   def main(args: Array[String]): Unit =
-    run(args.toList.tail)
+    run(args.toList)
 }

--- a/tools/src/main/scala/au/com/cba/omnia/ebenezer/cli/CatAsJson.scala
+++ b/tools/src/main/scala/au/com/cba/omnia/ebenezer/cli/CatAsJson.scala
@@ -1,0 +1,85 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.ebenezer.cli
+
+import org.apache.hadoop.conf.Configuration
+
+import argonaut._, Argonaut._
+
+import au.com.cba.omnia.ebenezer.fs.Glob
+import au.com.cba.omnia.ebenezer.introspect._
+
+/**
+ * Cli tool to read parquet file contents as Json.
+ * It expects a path or path glob in HDFS with parquet files.
+ * It will output to stdout.
+ */
+object CatAsJson {
+  def run(patterns: List[String]): Unit = {
+    val conf    = new Configuration
+    val paths   = Glob.patterns(conf, patterns)
+    val records = paths.foldLeft(Iterator[Record]())((iter, path) =>
+      iter ++ ParquetIntrospectTools.streamFromPath(conf, path)
+    )
+    records.map(_.asJson).foreach(println)
+  }
+
+  implicit def RecordEncodeJson: EncodeJson[Record] =
+    EncodeJson((record: Record) => recordToJson(record))
+
+  def flattenJson(l: List[Json]): Json =
+    l.foldLeft(Json())((a: Json, b: Json) => a.deepmerge(b))
+
+  def recordToJson(record: Record): Json =
+    flattenJson(record.data.map(fieldToJson(_)))
+
+  def fieldToJson(field: Field): Json =
+    Json(field.name -> valueToJson(field.value))
+
+  def valueToJson(value: Value): Json = {
+    value match {
+      case BooleanValue(v)   => jBool(v)
+      case EnumValue(v)      => Json.array(jString(v))
+      case IntValue(v)       => jNumber(v)
+      case LongValue(v)      => jNumber(v)
+      case FloatValue(v)     => jNumberOrString(v)
+      case DoubleValue(v)    => jNumber(v)
+      case StringValue(v)    => jString(v)
+      case ListValue(v)      => jArray(v.map(valueToJson(_)))
+      case MapValue(v)       => mapValueToJson(v)
+      case RecordValue(v)    => jArray(v.data.map(fieldToJson(_)))
+      case null              => jNull
+    }
+  }
+
+  def mapValueToJson(mapValue: Map[Value, Value]): Json = {
+    if(mapValue.keys.forall(_.isInstanceOf[StringValue])) {
+      jObjectAssocList(
+        mapValue.map { case (k, v)  =>
+          (String.valueOf(k), valueToJson(v))
+        }.toList)
+    } else {
+      jArray(
+        mapValue.map { case (k, v)  =>
+          jObjectFields(("key", valueToJson(k)), ("value", valueToJson(v)))
+         }.toList
+      )
+    }
+  }
+
+  def main(args: Array[String]): Unit =
+    run(args.toList)
+
+}

--- a/tools/src/main/scala/au/com/cba/omnia/ebenezer/fs/Glob.scala
+++ b/tools/src/main/scala/au/com/cba/omnia/ebenezer/fs/Glob.scala
@@ -15,8 +15,7 @@
 package au.com.cba.omnia.ebenezer
 package fs
 
-import org.apache.hadoop.fs.Path
-import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.fs.{PathNotFoundException, Path, FileSystem}
 import org.apache.hadoop.conf.Configuration
 
 object Glob {
@@ -25,6 +24,10 @@ object Glob {
 
   def paths(conf: Configuration, paths: List[Path]): List[Path] = {
     val fs = FileSystem.get(conf)
-    paths.flatMap(path => fs.globStatus(path).toList.map(_.getPath))
+    paths.flatMap(path => Option(fs.globStatus(path))
+        .getOrElse(throw new PathNotFoundException(String.valueOf(path)))
+        .toList
+        .map(_.getPath)
+      )
   }
 }

--- a/tools/src/test/scala/au/com/cba/omnia/ebenezer/cli/CatAsJsonSpec.scala
+++ b/tools/src/test/scala/au/com/cba/omnia/ebenezer/cli/CatAsJsonSpec.scala
@@ -1,0 +1,198 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.ebenezer.cli
+
+import java.util.UUID
+
+import argonaut._, Argonaut._
+
+import com.twitter.scalding.typed.IterablePipe
+import com.twitter.scrooge.ThriftStruct
+
+import org.scalacheck.Arbitrary
+
+import org.specs2.execute.Result
+
+import au.com.cba.omnia.ebenezer.ParquetLogging
+import au.com.cba.omnia.ebenezer.cli.CatAsJson._
+import au.com.cba.omnia.ebenezer.introspect._
+import au.com.cba.omnia.ebenezer.scrooge.ParquetScroogeSource
+import au.com.cba.omnia.ebenezer.test._, ThriftArbitraries._ , JavaArbitraries._
+
+import au.com.cba.omnia.thermometer.context.Context
+import au.com.cba.omnia.thermometer.core.Thermometer._
+import au.com.cba.omnia.thermometer.core._
+
+object CatAsJsonSpec extends ThermometerSpec with ParquetLogging { def is = s2"""
+
+CatAsJson usage
+================
+  Read some parquet as records and cat it as JSON                 $usage
+
+  Read some parquet as records, extract fields and cat as a flattened JSON $checkFlattenedFields
+
+Types
+======
+  Read booleans                                                   ${check("boolean", fromBoolish)}
+  Read doubles                                                    ${check("double", fromDoublish)}
+  Read bytes                                                      ${check("byte", fromBytish)}
+  Read shorts                                                     ${check("short", fromShortish)}
+  Read ints                                                       ${check("int", fromIntish)}
+  Read longs                                                      ${check("long", fromLongish)}
+  Read strings                                                    ${check("string", fromStringish)}
+  Read nested                                                     ${check("nested", fromNestedish)}
+  Read lists                                                      ${check("list", fromListish)}
+  Read maps                                                       ${check("map", fromMapish)}
+  Read maps with numeric key                                      ${check("map", fromMapish2)}
+  Read maps with list as key                                      ${check("map", fromMapish3)}
+  Read enums                                                      ${check("enum", fromEnumish)}
+  """
+
+  val data = List(
+    Customer("CUSTOMER-1", "Fred", "Bedrock",   40),
+    Customer("CUSTOMER-2", "Wilma", "Bedrock",  40),
+    Customer("CUSTOMER-3", "Barney", "Bedrock", 39),
+    Customer("CUSTOMER-4", "BamBam", "Bedrock",  2)
+  )
+
+  implicit def CustomerEncode: EncodeJson[Customer] =
+    jencode4L((c: Customer) => (c.id, c.name, c.address, c.age))(
+      Customer.IdField.name,
+      Customer.NameField.name,
+      Customer.AddressField.name,
+      Customer.AgeField.name
+    )
+
+  implicit def CustomerDecode: DecodeJson[Customer] =
+    jdecode4L(Customer.apply)(
+      Customer.IdField.name,
+      Customer.NameField.name,
+      Customer.AddressField.name,
+      Customer.AgeField.name
+    )
+
+  def customerToJsonKV(c: Customer) = List(
+      Map(Customer.IdField.name       -> c.id     ).asJson,
+      Map(Customer.NameField.name     -> c.name   ).asJson,
+      Map(Customer.AddressField.name  -> c.address).asJson,
+      Map(Customer.AgeField.name      -> c.age    ).asJson
+    )
+
+  def usage =
+    withData(name, data)(context => {
+      val result = context.glob(name </> "*.parquet").flatMap(
+        ParquetIntrospectTools.listFromPath(jobConf, _)
+      )
+        .map(CatAsJson.recordToJson(_))
+        .flatMap(x => Parse.decodeOption[Customer](x.toString))
+
+      result must_== data
+    })
+
+  def checkFlattenedFields =
+    withData(name, data)(context => {
+      val result = context.glob(name </> "*.parquet").flatMap(
+        ParquetIntrospectTools.listFromPath(jobConf, _)
+      )
+        .flatMap(x => x.data.map(CatAsJson.fieldToJson(_)))
+
+      result.toSet must_== data.map(customerToJsonKV(_)).flatten.toSet
+    })
+
+  def fromBoolish: Boolish => Json = d => Record(List(
+    Field("value", BooleanValue(d.value))
+  )).asJson
+
+  def fromDoublish: Doublish => Json = d => Record(List(
+    Field("value", DoubleValue(d.value))
+  )).asJson
+
+  def fromBytish: Bytish => Json = d => Record(List(
+    Field("value", IntValue(d.value))
+  )).asJson
+
+  def fromShortish: Shortish => Json = d => Record(List(
+    Field("value", IntValue(d.value))
+  )).asJson
+
+  def fromIntish: Intish => Json = d => Record(List(
+    Field("value", IntValue(d.value))
+  )).asJson
+
+  def fromLongish: Longish => Json = d => Record(List(
+    Field("value", LongValue(d.value))
+  )).asJson
+
+  def fromStringish: Stringish => Json = d => Record(List(
+    Field("value", StringValue(d.value))
+  )).asJson
+
+  def fromNestedish: Nestedish => Json = d => Record(List(
+    Field("value", RecordValue(
+      Record(List(
+        Field("value", StringValue(d.value.value))
+      ))
+    ))
+  )).asJson
+
+  def fromListish: Listish => Json = d => Record(List(
+    Field("values", ListValue(d.values.toList.map(StringValue)))
+  )).asJson
+
+  def fromMapish: Mapish => Json = d => Record(List(
+    Field("values", MapValue(Map(d.values.toList.map({
+      case (k, v) => StringValue(k) -> StringValue(v)
+    }):_*)))
+  )).asJson
+
+  def fromMapish2: Mapish2 => Json = d => Record(List(
+    Field("values", MapValue(Map(d.values.toList.map({
+      case (k, v) => LongValue(k) -> StringValue(v)
+    }):_*)))
+  )).asJson
+
+  def fromMapish3: Mapish3 => Json = d => Record(List(
+    Field("values", MapValue(Map(d.values.toList.map({
+      case (k, v) => ListValue(k.map(StringValue(_)).toList) -> StringValue(v)
+    }):_*)))
+  )).asJson
+
+  def fromEnumish: Enumish => Json = d => Record(List(
+    Field("value", EnumValue(d.value.name.toUpperCase))
+  )).asJson
+
+  def fromCustomer: Customer => Json = customer => Record(List(
+    Field("id", StringValue(customer.id)),
+    Field("name", StringValue(customer.name)),
+    Field("address", StringValue(customer.address)),
+    Field("age", IntValue(customer.age))
+  )).asJson
+
+  def withData[A <: ThriftStruct](name: String, data: List[A])(check: Context => Result)(implicit M: Manifest[A]) = {
+    executesOk(IterablePipe(data).writeExecution(ParquetScroogeSource[A](name)))
+    expectations(check)
+  }
+
+  def check[A <: ThriftStruct](name: String, converter: A => Json)(implicit A: Arbitrary[A], M: Manifest[A]) =
+    prop { (data: List[A], uuid: UUID) =>
+      withData(name, data)(context => {
+        val result = context.glob(name </> "*.parquet").flatMap(
+          ParquetIntrospectTools.listFromPath(jobConf, _)
+        ).map(CatAsJson.recordToJson(_))
+
+        result.toSet must_== data.map(converter).toSet
+      })
+    }.set(minTestsOk = 10)
+}

--- a/tools/src/test/scala/au/com/cba/omnia/ebenezer/introspect/ParquetIntrospectToolsSpec.scala
+++ b/tools/src/test/scala/au/com/cba/omnia/ebenezer/introspect/ParquetIntrospectToolsSpec.scala
@@ -24,13 +24,14 @@ import org.scalacheck.Arbitrary
 
 import org.specs2.execute.Result
 
+import au.com.cba.omnia.ebenezer.ParquetLogging
 import au.com.cba.omnia.ebenezer.test._, ThriftArbitraries._, JavaArbitraries._
 import au.com.cba.omnia.ebenezer.scrooge.ParquetScroogeSource
 
 import au.com.cba.omnia.thermometer.core._, Thermometer._
 import au.com.cba.omnia.thermometer.context.Context
 
-object ParquetIntrospectToolsSpec extends ThermometerSpec { def is = s2"""
+object ParquetIntrospectToolsSpec extends ThermometerSpec with ParquetLogging { def is = s2"""
 
 Introspect usage
 ================

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "0.18.1"
+version in ThisBuild := "0.18.2"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
This change adds `CatAsJson` under `tools` project, Which would `Cat` Parquet files as JSON.
Also, Have updated the `glob` to throw correct exception when an invalid path is provided.