### PR TITLE
Added missing Cloudera plugin resolver to fix build.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,8 @@
 
 resolvers ++= Seq(
   Resolver.url("commbank-releases-ivy", new URL("http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy"))(Patterns("[organization]/[module]_[scalaVersion]_[sbtVersion]/[revision]/[artifact](-[classifier])-[revision].[ext]")),
-  "commbank-releases" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local"
+  "commbank-releases" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local",
+  "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/"
 )
 
 val uniformVersion = "1.2.4-20150513065051-9b4cf64"


### PR DESCRIPTION
`ebenezer` has stopped building successfully in the last week because it's unable to resolve `libthrift;0.9.0-cdh-5-2`. `libthrift` is required by the `humbug-plugin`, and the resolver for this dependency must be added explicitly to the list of plugin resolvers of `maestro`. Strangely, the last commit https://travis-ci.org/CommBank/ebenezer/builds/68919373 passed on Travis at the time, but in the last week this error has turned up with no code changes to `ebenezer`, `uniform`, or `humbug` inbetween.

A similar problem occurred with `maestro` in the last week: https://github.com/CommBank/maestro/pull/424

Adding the Cloudera repository to the list of plugin resolvers should fix this.

Error message from https://travis-ci.org/CommBank/ebenezer/builds/68919373:

```
...[info] Resolving org.apache.thrift#libthrift;0.9.0-cdh5-2 ...
[warn] 	module not found: org.apache.thrift#libthrift;0.9.0-cdh5-2
[warn] ==== typesafe-ivy-releases: tried
[warn]   https://repo.typesafe.com/typesafe/ivy-releases/org.apache.thrift/libthrift/0.9.0-cdh5-2/ivys/ivy.xml
[warn] ==== sbt-plugin-releases: tried
[warn]   https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/org.apache.thrift/libthrift/0.9.0-cdh5-2/ivys/ivy.xml
[warn] ==== local: tried
[warn]   /home/travis/.ivy2/local/org.apache.thrift/libthrift/0.9.0-cdh5-2/ivys/ivy.xml
[warn] ==== public: tried
[warn]   https://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.0-cdh5-2/libthrift-0.9.0-cdh5-2.pom
[warn] ==== commbank-releases-ivy: tried
[warn]   http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy/org/apache/thrift/libthrift_[scalaVersion]_[sbtVersion]/0.9.0-cdh5-2/ivy-0.9.0-cdh5-2.xml
[warn] ==== commbank-releases: tried
[warn]   http://commbank.artifactoryonline.com/commbank/ext-releases-local/org/apache/thrift/libthrift/0.9.0-cdh5-2/libthrift-0.9.0-cdh5-2.pom
...
```
And:
```
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: org.apache.thrift#libthrift;0.9.0-cdh5-2: not found
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn] 	Note: Unresolved dependencies path:
[warn] 		org.apache.thrift:libthrift:0.9.0-cdh5-2
[warn] 		  +- com.twitter:bijection-scrooge_2.10:0.7.2-OMNIA1
[warn] 		  +- au.com.cba.omnia:humbug-core_2.10:0.6.1-20150513010955-5eb6297
[warn] 		  +- au.com.cba.omnia:humbug-generator_2.10:0.6.1-20150513010955-5eb6297 ()
[warn] 		  +- au.com.cba.omnia:humbug-plugin:0.6.1-20150513010955-5eb6297 (sbtVersion=0.13, scalaVersion=2.10) (/home/travis/build/CommBank/ebenezer/project/plugins.sbt#L30-31)
[warn] 		  +- default:ebenezer-build:0.1-SNAPSHOT (sbtVersion=0.13, scalaVersion=2.10)
sbt.ResolveException: unresolved dependency: org.apache.thrift#libthrift;0.9.0-cdh5-2: not found
	at sbt.IvyActions$.sbt$IvyActions$$resolve(IvyActions.scala:291)
	at sbt.IvyActions$$anonfun$updateEither$1.apply(IvyActions.scala:188)
	at sbt.IvyActions$$anonfun$updateEither$1.apply(IvyActions.scala:165)
	at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:155)
	at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:155)
	at sbt.IvySbt$$anonfun$withIvy$1.apply(Ivy.scala:132)
	at sbt.IvySbt.sbt$IvySbt$$action$1(Ivy.scala:57)
	at sbt.IvySbt$$anon$4.call(Ivy.scala:65)
	at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:93)
	at xsbt.boot.Locks$GlobalLock.xsbt$boot$Locks$GlobalLock$$withChannelRetries$1(Locks.scala:78)
	at xsbt.boot.Locks$GlobalLock$$anonfun$withFileLock$1.apply(Locks.scala:97)
	at xsbt.boot.Using$.withResource(Using.scala:10)
	at xsbt.boot.Using$.apply(Using.scala:9)
	at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:58)
	at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:48)
	at xsbt.boot.Locks$.apply0(Locks.scala:31)
	at xsbt.boot.Locks$.apply(Locks.scala:28)
	at sbt.IvySbt.withDefaultLogger(Ivy.scala:65)
	at sbt.IvySbt.withIvy(Ivy.scala:127)
	at sbt.IvySbt.withIvy(Ivy.scala:124)
	at sbt.IvySbt$Module.withModule(Ivy.scala:155)
	at sbt.IvyActions$.updateEither(IvyActions.scala:165)
	at sbt.Classpaths$$anonfun$sbt$Classpaths$$work$1$1.apply(Defaults.scala:1369)
	at sbt.Classpaths$$anonfun$sbt$Classpaths$$work$1$1.apply(Defaults.scala:1365)
	at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$87.apply(Defaults.scala:1399)
	at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$87.apply(Defaults.scala:1397)
	at sbt.Tracked$$anonfun$lastOutput$1.apply(Tracked.scala:37)
	at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:1402)
	at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:1396)
	at sbt.Tracked$$anonfun$inputChanged$1.apply(Tracked.scala:60)
	at sbt.Classpaths$.cachedUpdate(Defaults.scala:1419)
	at sbt.Classpaths$$anonfun$updateTask$1.apply(Defaults.scala:1348)
	at sbt.Classpaths$$anonfun$updateTask$1.apply(Defaults.scala:1310)
	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:235)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
[error] (*:update) sbt.ResolveException: unresolved dependency: org.apache.thrift#libthrift;0.9.0-cdh5-2: not found
The command "sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci '; project core; set fork in Test := false; test; project hive; set fork in Test := false; test; project test; set fork in Test := false; test; project all; package; project example; set fork in Test := false; test; assembly; project compat; set fork in Test := false; test; project tools; set fork in Test := false; set parallelExecution in Test := false; test; assembly' && ci/sbt-deploy.sh && ci/gh-pages.sh" exited with 1.
```