### PR TITLE
Support for unions in ebenezer with scrooge 3.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - ci/sbt-setup.sh
 - ci/sbt-setup-version.sh
 script:
-- sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci '; project core; set fork in Test := false; test; project hive; set fork in Test := false; test; project test; set fork in Test := false; test; project all; package; project example; set fork in Test := false; test; assembly; project compat; set fork in Test := false; test; project tools; set fork in Test := false; set parallelExecution in Test := false; test; assembly'
+- sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci '; project core; set fork in Test := false; test; project hive; set fork in Test := false; test; project test; set fork in Test := false; test; project all; package; project example; set fork in Test := false; test; assembly; project compat; set fork in Test := false; test; project tools; set fork in Test := false; set parallelExecution in Test := false; set logBuffered := false; test; assembly'
   && ci/sbt-deploy.sh && ci/gh-pages.sh
 after_script:
 - rm -rf ci

--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ScroogeMetaHelper.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ScroogeMetaHelper.scala
@@ -1,0 +1,81 @@
+//   Copyright 2015 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.ebenezer.scrooge
+
+import com.twitter.scrooge.{ThriftStructField, ThriftStructCodec, ThriftStruct}
+
+import org.apache.thrift.protocol.TField
+
+/** This object provides com.twitter.scrooge.ThriftStructMetaData information,
+ *  using copies of the code found in that module (version 3.17). Metadata
+ *  cannot be used on thrift union fields (until scrooge version 3.19), hence
+ *  this ugly and brittle workaround.
+ */
+object ScroogeMetaHelper {
+  /** verbatim copy of scrooge 3.17::com.twitter.scrooge.ThriftStructMetaData.scala */
+  def toCamelCase(str: String): String = {
+    str.takeWhile(_ == '_') +
+      str
+        .split('_')
+        .filterNot(_.isEmpty)
+        .zipWithIndex.map { case (part, ind) =>
+          val first = if (ind == 0) part(0).toLower else part(0).toUpper
+          val isAllUpperCase = part.forall(_.isUpper)
+          val rest = if (isAllUpperCase) part.drop(1).toLowerCase else part.drop(1)
+          new StringBuilder(part.size).append(first).append(rest)
+        }
+        .mkString
+  }
+
+  /** This code is mostly a copy of com.twitter.scrooge.ThriftStructMetaData.fields
+    * in scrooge 3.17, but handles the /method/ retrieval failures which occur for unions.
+    */
+  //
+  def fieldsInStruct[T <: ThriftStruct](codec: ThriftStructCodec[T]): Seq[ThriftStructField[T]] = {
+    // find out names and classes
+    val codecClass  = codec.getClass
+    val structClass = codecClass
+        .getClassLoader
+        .loadClass(codecClass.getName.init) // drop '$' from object name
+        .asInstanceOf[Class[T]]
+
+    // retrieve the fields
+    codecClass.getMethods.toList.filter(m =>
+      m.getParameterTypes.isEmpty && m.getReturnType == classOf[TField]
+    ).map { m =>
+      val tfield = m.invoke(codec).asInstanceOf[TField]
+
+      val manifest: scala.Option[Manifest[_]] = try {
+        Some(
+          codecClass
+            .getMethod(m.getName + "Manifest")
+            .invoke(codec)
+            .asInstanceOf[Manifest[_]]
+        )
+      } catch {
+        case _: Throwable => None
+      }
+
+      val method = try {
+        structClass.getMethod(toCamelCase(tfield.name))
+        // Method does not exist for fields that are union members, we return null.
+        // Needs matching code in ScroogeStructConverter.isUnionField
+      } catch { case _: NoSuchMethodException => null }
+
+      new ThriftStructField[T](tfield, method, manifest)
+    }
+  }
+
+}

--- a/core/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/Unions.scala
+++ b/core/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/Unions.scala
@@ -1,0 +1,136 @@
+//   Copyright 2015 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.ebenezer
+package scrooge
+
+import com.twitter.scalding.TDsl._
+import com.twitter.scalding._
+import com.twitter.scalding.typed.IterablePipe
+
+import au.com.cba.omnia.thermometer.core.Thermometer._
+import au.com.cba.omnia.thermometer.core.ThermometerSpec
+import au.com.cba.omnia.thermometer.fact.PathFactoids._
+
+import au.com.cba.omnia.ebenezer.ParquetLogging
+import au.com.cba.omnia.ebenezer.scrooge.ParquetScroogeSourceSpec._
+import au.com.cba.omnia.ebenezer.test.Customers.{NewCustomer, OldCustomer}
+import au.com.cba.omnia.ebenezer.test.NestedCustomers.NestedA
+import au.com.cba.omnia.ebenezer.test.WideUnion._
+import au.com.cba.omnia.ebenezer.test._
+
+object Unions  extends ThermometerSpec with ParquetLogging { def is = s2"""
+
+Parquet with Unions
+===================
+
+  Write union to parquet                      $writeU
+  Read union from parquet                     $readU
+  Write wide union to parquet                 $writeWide
+  Write and read nested unions                $writeReadNested
+"""
+
+  val doubleCusts: List[Customers] =
+    data.flatMap(cust => List(OldCustomer(cust), NewCustomer(customerNew(cust))) )
+
+  val nestedCusts: List[NestedCustomers] =
+    doubleCusts.map(c => NestedA(c))
+
+  val structCusts: List[UnionStruct] =
+    nestedCusts.map( c => UnionStruct(AOrB.A, Some(c)))
+
+  // data for the wide union (99 i32 fields a1..a99)
+  val wideData: List[WideUnion] = List(
+     A1(1),A2(2),A3(3),A4(4),A5(5),A6(6),A7(7),A8(8),A9(9)
+    ,A10(10),A11(11),A12(12),A13(13),A14(14),A15(15),A16(16),A17(17),A18(18),A19(19)
+    ,A20(20),A21(21),A22(22),A23(23),A24(24),A25(25),A26(26),A27(27),A28(28),A29(29)
+    ,A30(30),A31(31),A32(32),A33(33),A34(34),A35(35),A36(36),A37(37),A38(38),A39(39)
+    ,A40(40),A41(41),A42(42),A43(43),A44(44),A45(45),A46(46),A47(47),A48(48),A49(49)
+    ,A50(50),A51(51),A52(52),A53(53),A54(54),A55(55),A56(56),A57(57),A58(58),A59(59)
+    ,A60(60),A61(61),A62(62),A63(63),A64(64),A65(65),A66(66),A67(67),A68(68),A69(69)
+    ,A70(70),A71(71),A72(72),A73(73),A74(74),A75(75),A76(76),A77(77),A78(78),A79(79)
+    ,A80(80),A81(81),A82(82),A83(83),A84(84),A85(85),A86(86),A87(87),A88(88),A89(89)
+    ,A90(90),A91(91),A92(92),A93(93),A94(94),A95(95),A96(96),A97(97),A98(98),A99(99)
+  )
+
+  def writing =
+    IterablePipe(doubleCusts)
+      .writeExecution(ParquetScroogeSource[Customers]("doubleCusts"))
+
+  def writeU = {
+    executesOk(writing)
+    facts(
+      "doubleCusts" </> "_SUCCESS"   ==> exists,
+      "doubleCusts" </> "*.parquet"  ==> records(ParquetThermometerRecordReader[Customers], doubleCusts)
+    )
+  }
+
+  def destruct(c: Customers): (String, String, String, Int) = (c: @unchecked) match {
+    case OldCustomer(c) => (c.id, c.name, c.address, c.age)
+    case NewCustomer(c) => (c.identifier.toString, c.name, c.address,  0 )
+  }
+
+  def reading =
+    ParquetScroogeSource[Customers]("doubleCusts")
+      .map( destruct(_) )
+      .writeExecution(TypedPsv("doubleCusts.psv"))
+
+  def readU = {
+    executesOk(writing.flatMap(_ => reading))
+
+    facts(
+      "doubleCusts.psv" </> "_SUCCESS"   ==> exists,
+      "doubleCusts.psv" </> "part-*"     ==> lines(data.flatMap(customer =>
+        List( List(customer.id, customer.name, customer.address, customer.age).mkString("|"),
+              List(customer.id.stripPrefix("CUSTOMER-"), customer.name, customer.address, 0).mkString("|"))))
+    )
+  }
+
+  def writeReadNested = {
+
+    def writeNested =
+      IterablePipe(structCusts)
+        .writeExecution(ParquetScroogeSource[UnionStruct]("structCusts"))
+
+    def readNested =
+      ParquetScroogeSource[UnionStruct]("structCusts")
+        .collect( {case UnionStruct(AOrB.A, Some(NestedA(c))) => destruct(c) })
+        .writeExecution(TypedPsv("doubleAgain.psv"))
+
+    executesOk(writeNested.flatMap(_ => readNested))
+    facts(
+      "structCusts" </> "_SUCCESS"   ==> exists,
+      "structCusts" </> "*.parquet"  ==> records(ParquetThermometerRecordReader[UnionStruct], structCusts),
+      "doubleAgain.psv" </> "part-*" ==> lines(data.flatMap(customer =>
+        List( List(customer.id, customer.name, customer.address, customer.age).mkString("|"),
+              List(customer.id.stripPrefix("CUSTOMER-"), customer.name, customer.address, 0).mkString("|")))
+      )
+    )
+  }
+
+
+  def doWrite =
+    IterablePipe(wideData)
+      .writeExecution(ParquetScroogeSource[WideUnion]("wideData"))
+
+  def writeWide = {
+    executesOk(doWrite)
+
+    facts(
+      "wideData" </> "_SUCCESS"   ==> exists,
+      "wideData" </> "*.parquet"  ==> records(ParquetThermometerRecordReader[WideUnion], wideData)
+      )
+  }
+
+}

--- a/core/src/test/thrift/scrooge/Unions.thrift
+++ b/core/src/test/thrift/scrooge/Unions.thrift
@@ -1,0 +1,139 @@
+//   Copyright 2015 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#@namespace scala au.com.cba.omnia.ebenezer.test
+
+include "Customer.thrift"
+include "CustomerNew.thrift"
+
+union Customers {
+  1: Customer.Customer       oldCustomer;
+  2: CustomerNew.CustomerNew newCustomer;
+}
+
+union NestedCustomers {
+  1: Customers nestedA;
+  2: Customers nestedB;
+}
+
+enum AOrB { a; b; }
+
+struct UnionStruct {
+  1: required AOrB constructor;
+  2: optional NestedCustomers nested;
+}
+
+union WideUnion {
+  // 99 fields (of one and the same type i32)
+  // you really want to have this written by a machine...
+  1: i32 a1;
+  2: i32 a2;
+  3: i32 a3;
+  4: i32 a4;
+  5: i32 a5;
+  6: i32 a6;
+  7: i32 a7;
+  8: i32 a8;
+  9: i32 a9;
+  10: i32 a10;
+  11: i32 a11;
+  12: i32 a12;
+  13: i32 a13;
+  14: i32 a14;
+  15: i32 a15;
+  16: i32 a16;
+  17: i32 a17;
+  18: i32 a18;
+  19: i32 a19;
+  20: i32 a20;
+  21: i32 a21;
+  22: i32 a22;
+  23: i32 a23;
+  24: i32 a24;
+  25: i32 a25;
+  26: i32 a26;
+  27: i32 a27;
+  28: i32 a28;
+  29: i32 a29;
+  30: i32 a30;
+  31: i32 a31;
+  32: i32 a32;
+  33: i32 a33;
+  34: i32 a34;
+  35: i32 a35;
+  36: i32 a36;
+  37: i32 a37;
+  38: i32 a38;
+  39: i32 a39;
+  40: i32 a40;
+  41: i32 a41;
+  42: i32 a42;
+  43: i32 a43;
+  44: i32 a44;
+  45: i32 a45;
+  46: i32 a46;
+  47: i32 a47;
+  48: i32 a48;
+  49: i32 a49;
+  50: i32 a50;
+  51: i32 a51;
+  52: i32 a52;
+  53: i32 a53;
+  54: i32 a54;
+  55: i32 a55;
+  56: i32 a56;
+  57: i32 a57;
+  58: i32 a58;
+  59: i32 a59;
+  60: i32 a60;
+  61: i32 a61;
+  62: i32 a62;
+  63: i32 a63;
+  64: i32 a64;
+  65: i32 a65;
+  66: i32 a66;
+  67: i32 a67;
+  68: i32 a68;
+  69: i32 a69;
+  70: i32 a70;
+  71: i32 a71;
+  72: i32 a72;
+  73: i32 a73;
+  74: i32 a74;
+  75: i32 a75;
+  76: i32 a76;
+  77: i32 a77;
+  78: i32 a78;
+  79: i32 a79;
+  80: i32 a80;
+  81: i32 a81;
+  82: i32 a82;
+  83: i32 a83;
+  84: i32 a84;
+  85: i32 a85;
+  86: i32 a86;
+  87: i32 a87;
+  88: i32 a88;
+  89: i32 a89;
+  90: i32 a90;
+  91: i32 a91;
+  92: i32 a92;
+  93: i32 a93;
+  94: i32 a94;
+  95: i32 a95;
+  96: i32 a96;
+  97: i32 a97;
+  98: i32 a98;
+  99: i32 a99;
+}

--- a/tools/src/test/scala/au/com/cba/omnia/ebenezer/cli/CatAsJsonSpec.scala
+++ b/tools/src/test/scala/au/com/cba/omnia/ebenezer/cli/CatAsJsonSpec.scala
@@ -194,5 +194,6 @@ Types
 
         result.toSet must_== data.map(converter).toSet
       })
-    }.set(minTestsOk = 10)
+    }.set(minTestsOk = 5)
 }
+

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "0.18.4"
+version in ThisBuild := "0.18.5"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
This change adds support for unions to ebenezer.
Scrooge 3.19 fixes the underlying problem, but ebenezer so far relies on 3.17.
While a nicer solution might be possible with the newer scrooge, this one should work for code generated by 3.19 as well.

\cc @shyam334 
