### PR TITLE
Adding partitions only if they don't already exist.

### DIFF
--- a/hive/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/hive/Hive.scala
+++ b/hive/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/hive/Hive.scala
@@ -388,7 +388,7 @@ object Hive extends ResultantOps[Hive] with ToResultantMonadOps {
                            Hive.fail[List[String]](s"$invalid are not valid partition paths for $database.$table")
       partitionPattern = pattern(mTable.getPartitionKeys.asScala.map(c => c.getName).toList) // Using metadata for the pattern
       partitions      <- Hive.result(partitionPaths.map(p => partition(mTable, partitionPattern, p)).sequence)
-      _               <- Hive.withClient(_.add_partitions(partitions.asJava))
+      _               <- Hive.withClient(_.add_partitions(partitions.asJava, true, false))
     } yield ()
   }
   

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "0.21.0"
+version in ThisBuild := "0.21.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
The initial implementation was trying to replicate what MSCK repair was doing. However, during in MSCK  if a batch update fails, it retries each partition one by one. Instead this implementation essentially lets the metastore handle preexisting partitions by ignoring them.