### PR TITLE
Parquet combine input support

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetCombineInputSupport.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetCombineInputSupport.scala
@@ -1,0 +1,154 @@
+package au.com.cba.omnia.ebenezer.scrooge
+
+import java.io.{DataInput, DataOutput}
+import java.util
+
+import collection.JavaConversions._
+
+import org.apache.hadoop.mapred._
+
+import parquet.hadoop.api.{InitContext, ReadSupport}
+import parquet.hadoop.{ParquetFileReader, ParquetInputFormat, ParquetInputSplit, ParquetRecordReader}
+import parquet.hadoop.mapred.{Container, DeprecatedParquetInputFormat}
+
+/**
+  * Eternal workaround for parquet 1.5 and cascading 2.6.1
+  * TODO: all the classes in this file need to be rewrote if we depend on a new parquet/cascading version
+  */
+class DeprecatedParquetCombineInputFormat[T] extends DeprecatedParquetInputFormat[T] {
+  override def getSplits(job: JobConf, numSplits: Int) = {
+    val footers = getFooters(job)
+    val mapreduceFileSplits = realInputFormat.getSplits(job, footers)
+
+    if (mapreduceFileSplits == null)
+      null
+    else
+      mapreduceFileSplits.map(new ParquetFileSplitWrapper(_)).toArray
+  }
+
+  override def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter) =
+    new CombineRecordReader[T](realInputFormat, split, job, reporter)
+}
+
+/**
+  * TODO: This class needs to be rewrote for parquet 1.6
+  * TODO: This class can be removed for parquet 1.7+
+  */
+class CombineRecordReader[V](
+                              newInputFormat: ParquetInputFormat[V],
+                              oldSplit: InputSplit,
+                              oldJobConf: JobConf,
+                              reporter: Reporter
+                            )
+  extends RecordReader[Void, Container[V]] {
+  val realReader    : ParquetRecordReader[V] = new ParquetRecordReader(newInputFormat.getReadSupport(oldJobConf), ParquetInputFormat.getFilter(oldJobConf))
+  val splitLen      : Long                   = oldSplit.getLength
+  var valueContainer: Container[V]           = null
+  var firstRecord   : Boolean                = false
+  var eof           : Boolean                = false
+
+  oldSplit match {
+    case wrapper: ParquetFileSplitWrapper =>
+      // plan stage
+      realReader.initialize(oldSplit.asInstanceOf[ParquetFileSplitWrapper].realSplit, oldJobConf, reporter)
+    case split: FileSplit =>
+      // runtime
+      val oldFileSplit = oldSplit.asInstanceOf[FileSplit]
+      val finalPath = oldFileSplit.getPath
+      val parquetMetadata = ParquetFileReader.readFooter(oldJobConf, finalPath)
+      val blocks = parquetMetadata.getBlocks
+      val readerSupportClass = ParquetInputFormat.getReadSupportClass(oldJobConf).newInstance().asInstanceOf[ReadSupport[V]]
+      val readContext = readerSupportClass.init(
+        new InitContext(
+          oldJobConf,
+          parquetMetadata.getFileMetaData.getKeyValueMetaData.mapValues {
+            value =>
+              val set = new util.HashSet[String]()
+              set.add(value)
+              set
+          },
+          parquetMetadata.getFileMetaData.getSchema
+        ))
+
+      val newSplit = new ParquetInputSplit(
+        oldFileSplit.getPath,
+        oldFileSplit.getStart,
+        oldFileSplit.getLength,
+        oldFileSplit.getLocations,
+        blocks,
+        readContext.getRequestedSchema.toString,
+        parquetMetadata.getFileMetaData.getSchema.toString.intern,
+        parquetMetadata.getFileMetaData.getKeyValueMetaData,
+        readContext.getReadSupportMetadata
+      )
+      realReader.initialize(newSplit, oldJobConf, reporter)
+    case _ =>
+      throw new IllegalArgumentException("Invalid Split: " + oldSplit)
+  }
+
+  if (realReader.nextKeyValue()) {
+    firstRecord = true
+    valueContainer = new Container()
+    valueContainer.set(realReader.getCurrentValue)
+  } else {
+    eof = true
+  }
+
+  def close() = realReader.close()
+
+  def createKey() = null
+
+  def createValue() = valueContainer
+
+  def getPos = (splitLen.toFloat * getProgress).toLong
+
+  def getProgress = realReader.getProgress
+
+  def next(key: Void, value: Container[V]): Boolean = {
+    if (eof)
+      false
+    else if (firstRecord) {
+      firstRecord = false
+      true
+    } else {
+      if (realReader.nextKeyValue()) {
+        if (value != null)
+          value.set(realReader.getCurrentValue)
+        true
+      }
+      else {
+        eof = true
+        false
+      }
+    }
+  }
+}
+
+/**
+  * TODO: This class can be removed for parquet 1.7+
+  */
+class ParquetFileSplitWrapper(split: ParquetInputSplit)
+
+  extends FileSplit(null, 0, 0, new Array[String](0)) {
+
+  var realSplit = split
+
+  def this() = this(null) // hadoop need this default constructor
+
+  override def write(out: DataOutput) = realSplit.write(out)
+
+  override def readFields(in: DataInput) = {
+    realSplit = new ParquetInputSplit()
+    realSplit.readFields(in)
+  }
+
+  override def getLength = realSplit.getLength
+
+  override def getLocations = realSplit.getLocations
+
+  override def getStart = realSplit.getStart
+
+  override def getPath = realSplit.getPath
+
+  override def toString = realSplit.toString
+}

--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeScheme.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeScheme.scala
@@ -47,3 +47,15 @@ object ParquetScroogeSchemeSupport {
   def parquetHdfsScheme[T <: ThriftStruct](implicit m: Manifest[T]): cascading.scheme.Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _] =
     HadoopSchemeInstance(new ParquetScroogeScheme[T].asInstanceOf[Scheme[_, _, _, _, _]])
 }
+
+class ParquetScroogeCombineScheme[A <: ThriftStruct : Manifest] extends ParquetScroogeScheme[A] {
+  override def sourceConfInit(flow: FlowProcess[JobConf], tap: Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]], conf: JobConf): Unit = {
+    conf.setInputFormat(classOf[DeprecatedParquetCombineInputFormat[_]])
+    ScroogeReadSupport.setAsParquetSupportClass[A](conf)
+  }
+}
+
+object ParquetScroogeCombineSchemeSupport{
+  def parquetHdfsScheme[T <: ThriftStruct](implicit m: Manifest[T]): cascading.scheme.Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _] =
+    HadoopSchemeInstance(new ParquetScroogeCombineScheme[T].asInstanceOf[Scheme[_, _, _, _, _]])
+}


### PR DESCRIPTION
Wrapper classes for parquet 1.5 to support combine input format.
With option
```
cascading.hadoop.hfs.combine.files=true
cascading.hadoop.hfs.combine.max.size=268435456
```
enabled, the planner will assign multipe input files(in text or
parquet format) to an single mapper based input file size and
localtion. It will solve the memory and performance problems when
reading lots of small input files.

Parquet 1.7+ or cascading 3+ has solved this problem, however CDH
release is still sticking to parquet 1.5 in the latest version and
scalding is using cascading 2.6.1 .

There're 3 problem with this PR, I need your help:

1. Apparently this code can be refactored, however I'm not fluent in
scala, can you please provide some code samples to help me remove
the duplicate code in this PR?
2. Is that possbile to test the combine behavior on ebenezer level?
or we should test it in maestro level?
3. Based on my tests on cluster, empty parquet file will cause an
index out of range exception, looks like a cascading problem. I'm
currently investigating it. It would be great if someone familiar
with cascading can help me with it.