### PR TITLE
Add commit option to ParquetScroogeSource

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeScheme.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeScheme.scala
@@ -31,11 +31,15 @@ import com.twitter.scalding.HadoopSchemeInstance
 
 import com.twitter.scrooge.ThriftStruct
 
-class ParquetScroogeScheme[A <: ThriftStruct : Manifest] extends ParquetValueScheme[A] {
+class ParquetScroogeScheme[A <: ThriftStruct : Manifest](markSuccess: Boolean) extends ParquetValueScheme[A] {
   override def sinkConfInit(flow: FlowProcess[JobConf], tap: Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]], conf: JobConf): Unit = {
     conf.setOutputFormat(classOf[DeprecatedParquetOutputFormat[_]])
+    if (!markSuccess) {
+      conf.set("mapreduce.fileoutputcommitter.marksuccessfuljobs", "false")
+    }
     ScroogeWriteSupport.setAsParquetSupportClass[A](conf)
   }
+
 
   override def sourceConfInit(flow: FlowProcess[JobConf], tap: Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]], conf: JobConf): Unit = {
     conf.setInputFormat(classOf[DeprecatedParquetInputFormat[_]])
@@ -44,6 +48,6 @@ class ParquetScroogeScheme[A <: ThriftStruct : Manifest] extends ParquetValueSch
 }
 
 object ParquetScroogeSchemeSupport {
-  def parquetHdfsScheme[T <: ThriftStruct](implicit m: Manifest[T]): cascading.scheme.Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _] =
-    HadoopSchemeInstance(new ParquetScroogeScheme[T].asInstanceOf[Scheme[_, _, _, _, _]])
+  def parquetHdfsScheme[T <: ThriftStruct](markSuccess: Boolean)(implicit m: Manifest[T]): cascading.scheme.Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _] =
+    HadoopSchemeInstance(new ParquetScroogeScheme[T](markSuccess).asInstanceOf[Scheme[_, _, _, _, _]])
 }

--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeScheme.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeScheme.scala
@@ -34,9 +34,7 @@ import com.twitter.scrooge.ThriftStruct
 class ParquetScroogeScheme[A <: ThriftStruct : Manifest](markSuccess: Boolean) extends ParquetValueScheme[A] {
   override def sinkConfInit(flow: FlowProcess[JobConf], tap: Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]], conf: JobConf): Unit = {
     conf.setOutputFormat(classOf[DeprecatedParquetOutputFormat[_]])
-    if (!markSuccess) {
-      conf.set("mapreduce.fileoutputcommitter.marksuccessfuljobs", "false")
-    }
+    conf.set("mapreduce.fileoutputcommitter.marksuccessfuljobs", s"$markSuccess")
     ScroogeWriteSupport.setAsParquetSupportClass[A](conf)
   }
 

--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeSource.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeSource.scala
@@ -25,17 +25,17 @@ import com.twitter.scrooge.ThriftStruct
   * A scalding source to read Scrooge Thrift structs from partitioned files using parquet as the
   * underlying storage format. It will ignore the partition columns and only read the thrift struct
   * from the parquet file.
-  * 
+  *
   * Use [[PartitionHiveParquetScroogeSink]] for write.
   */
-case class ParquetScroogeSource[T <: ThriftStruct](p : String*)(
+class ParquetScroogeSource[T <: ThriftStruct](p : Seq[String], markSuccess: Boolean)(
   implicit m : Manifest[T], conv: TupleConverter[T], set: TupleSetter[T]
 ) extends FixedPathSource(p: _*)
   with TypedSink[T]
   with Mappable[T]
   with java.io.Serializable {
 
-  override def hdfsScheme = ParquetScroogeSchemeSupport.parquetHdfsScheme[T]
+  override def hdfsScheme = ParquetScroogeSchemeSupport.parquetHdfsScheme[T](markSuccess)
 
   override def createTap(readOrWrite: AccessMode)(implicit mode: Mode): Tap[_, _, _] = mode match {
     case Local(_) => sys.error(s"Local mode is currently not supported for ${toString}")
@@ -47,4 +47,14 @@ case class ParquetScroogeSource[T <: ThriftStruct](p : String*)(
 
   override def setter[U <: T] =
     TupleSetter.asSubSetter[T, U](TupleSetter.of[T])
+}
+
+object ParquetScroogeSource {
+  def apply[T <: ThriftStruct](p: String*)(
+    implicit m : Manifest[T], conv: TupleConverter[T], set: TupleSetter[T]) =
+      new ParquetScroogeSource[T](p, true)
+
+  def apply[T <: ThriftStruct](markSuccess: Boolean, p: String*)(
+    implicit m : Manifest[T], conv: TupleConverter[T], set: TupleSetter[T]) =
+      new ParquetScroogeSource[T](p, markSuccess)
 }

--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeSource.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeSource.scala
@@ -28,8 +28,8 @@ import com.twitter.scrooge.ThriftStruct
   *
   * Use [[PartitionHiveParquetScroogeSink]] for write.
   */
-class ParquetScroogeSource[T <: ThriftStruct](p : Seq[String], markSuccess: Boolean)(
-  implicit m : Manifest[T], conv: TupleConverter[T], set: TupleSetter[T]
+class ParquetScroogeSource[T <: ThriftStruct](p: Seq[String], markSuccess: Boolean)(
+  implicit m: Manifest[T], conv: TupleConverter[T], set: TupleSetter[T]
 ) extends FixedPathSource(p: _*)
   with TypedSink[T]
   with Mappable[T]
@@ -51,10 +51,10 @@ class ParquetScroogeSource[T <: ThriftStruct](p : Seq[String], markSuccess: Bool
 
 object ParquetScroogeSource {
   def apply[T <: ThriftStruct](p: String*)(
-    implicit m : Manifest[T], conv: TupleConverter[T], set: TupleSetter[T]) =
+    implicit m: Manifest[T], conv: TupleConverter[T], set: TupleSetter[T]) =
       new ParquetScroogeSource[T](p, true)
 
   def apply[T <: ThriftStruct](markSuccess: Boolean, p: String*)(
-    implicit m : Manifest[T], conv: TupleConverter[T], set: TupleSetter[T]) =
+    implicit m: Manifest[T], conv: TupleConverter[T], set: TupleSetter[T]) =
       new ParquetScroogeSource[T](p, markSuccess)
 }

--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/PartitionParquetScroogeSink.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/PartitionParquetScroogeSink.scala
@@ -53,7 +53,7 @@ case class PartitionParquetScroogeSink[A, T <: ThriftStruct](template: String, p
     new TemplatePartition(templateFields, template)
   }
 
-  val hdfsScheme = ParquetScroogeSchemeSupport.parquetHdfsScheme[T](true)
+  val hdfsScheme = ParquetScroogeSchemeSupport.parquetHdfsScheme[T](false)
   hdfsScheme.setSinkFields(Dsl.strFields(List("0")))
 
   override def createTap(readOrWrite: AccessMode)(implicit mode: Mode): Tap[_, _, _] = mode match {

--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/PartitionParquetScroogeSink.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/PartitionParquetScroogeSink.scala
@@ -53,12 +53,12 @@ case class PartitionParquetScroogeSink[A, T <: ThriftStruct](template: String, p
     new TemplatePartition(templateFields, template)
   }
 
-  val hdfsScheme = ParquetScroogeSchemeSupport.parquetHdfsScheme[T]
+  val hdfsScheme = ParquetScroogeSchemeSupport.parquetHdfsScheme[T](true)
   hdfsScheme.setSinkFields(Dsl.strFields(List("0")))
 
   override def createTap(readOrWrite: AccessMode)(implicit mode: Mode): Tap[_, _, _] = mode match {
     case hdfsMode @ Hdfs(_, jobConf) => readOrWrite match {
-      case Write => { 
+      case Write => {
         val tap = new PartitionParquetScroogeWriteTap(path, partition, hdfsScheme)
         tap.asInstanceOf[Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]]]
       }

--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/PartitionParquetScroogeSource.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/PartitionParquetScroogeSource.scala
@@ -24,7 +24,7 @@ import com.twitter.scrooge.ThriftStruct
 
 case class PartitionParquetScroogeSource[A, T <: ThriftStruct](template: String, path: String)(
   implicit m : Manifest[T], valueConverter: TupleConverter[T], partitionConverter: TupleConverter[A]
-) extends Source 
+) extends Source
   with Mappable[T]
   with java.io.Serializable {
 
@@ -33,7 +33,7 @@ case class PartitionParquetScroogeSource[A, T <: ThriftStruct](template: String,
     new TemplatePartition(templateFields, template)
   }
 
-  val hdfsScheme = ParquetScroogeSchemeSupport.parquetHdfsScheme[T]
+  val hdfsScheme = ParquetScroogeSchemeSupport.parquetHdfsScheme[T](true)
 
   override def createTap(readOrWrite: AccessMode)(implicit mode: Mode): Tap[_, _, _] = mode match {
     case hdfsMode @ Hdfs(_, jobConf) => readOrWrite match {
@@ -44,7 +44,7 @@ case class PartitionParquetScroogeSource[A, T <: ThriftStruct](template: String,
     case Local(_) => sys.error(s"Local mode is currently not supported for ${toString}")
     case x        => sys.error(s"$x mode is currently not supported for ${toString}")
   }
-  
+
   override def converter[U >: T] =
     TupleConverter.asSuperConverter[T, U](valueConverter)
 

--- a/core/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeSourceSpec.scala
+++ b/core/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/ParquetScroogeSourceSpec.scala
@@ -24,11 +24,9 @@ import au.com.cba.omnia.ebenezer.ParquetLogging
 import au.com.cba.omnia.ebenezer.test.{Customer, CustomerNew, Large, ParquetThermometerRecordReader}
 
 
-object ParquetScroogeSourceSpecWithSuccessFlag extends AbstractParquetScroogeSourceSpec(true) {
-}
+object ParquetScroogeSourceSpecWithSuccessFlag extends AbstractParquetScroogeSourceSpec(true)
 
-object ParquetScroogeSourceSpecNoSuccessFlag extends AbstractParquetScroogeSourceSpec(false) {
-}
+object ParquetScroogeSourceSpecNoSuccessFlag extends AbstractParquetScroogeSourceSpec(false)
 
 abstract class AbstractParquetScroogeSourceSpec(writeSuccessFlag: Boolean) extends ThermometerSpec with ParquetLogging { def is = s2"""
 

--- a/core/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/PartitionParquetScroogeSpec.scala
+++ b/core/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/PartitionParquetScroogeSpec.scala
@@ -72,7 +72,8 @@ PartitionParquetScrooge Source and Sink test
     executesOk(write)
 
     facts(
-      basePath </> "address=Bedrock"     </> "age=40" </> "*.parquet"  ==> recordCount(ParquetThermometerRecordReader[Customer], 2)
+      basePath </> "address=Bedrock"     </> "age=40" </> "_SUCCESS"   ==> missing  //Explicitly asserting this to document the behaviour
+    , basePath </> "address=Bedrock"     </> "age=40" </> "*.parquet"  ==> recordCount(ParquetThermometerRecordReader[Customer], 2)
     , basePath </> "address=Bedrock"     </> "age=39" </> "*.parquet"  ==> recordCount(ParquetThermometerRecordReader[Customer], 1)
     , basePath </> "address=Fragglerock" </> "age=2"  </> "*.parquet"  ==> recordCount(ParquetThermometerRecordReader[Customer], 1)
     )
@@ -83,13 +84,14 @@ PartitionParquetScrooge Source and Sink test
     executesOk(writeWith(Customer("CUSTOMER-5", "Tom", "Fragglerock", 10)))
 
     facts(
-      basePath </> "address=Bedrock"     </> "age=40" </> "*.parquet"  ==> recordCount(ParquetThermometerRecordReader[Customer], 2), 
+      basePath </> "address=Bedrock"     </> "age=40" </> "_SUCCESS"   ==> missing, //Explicitly asserting this to document the behaviour
+      basePath </> "address=Bedrock"     </> "age=40" </> "*.parquet"  ==> recordCount(ParquetThermometerRecordReader[Customer], 2),
       basePath </> "address=Bedrock"     </> "age=39" </> "*.parquet"  ==> recordCount(ParquetThermometerRecordReader[Customer], 1),
       basePath </> "address=Fragglerock" </> "age=2"  </> "*.parquet"  ==> recordCount(ParquetThermometerRecordReader[Customer], 1),
       basePath </> "address=Fragglerock" </> "age=10" </> "*.parquet"  ==> recordCount(ParquetThermometerRecordReader[Customer], 1)
     )
   }
-  
+
   def readTest = {
     executesOk(write.flatMap(_ => read))
 

--- a/core/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/Unions.scala
+++ b/core/src/test/scala/au/com/cba/omnia/ebenezer/scrooge/Unions.scala
@@ -24,7 +24,7 @@ import au.com.cba.omnia.thermometer.core.ThermometerSpec
 import au.com.cba.omnia.thermometer.fact.PathFactoids._
 
 import au.com.cba.omnia.ebenezer.ParquetLogging
-import au.com.cba.omnia.ebenezer.scrooge.ParquetScroogeSourceSpec._
+import au.com.cba.omnia.ebenezer.scrooge.ParquetScroogeSourceSpecWithSuccessFlag._
 import au.com.cba.omnia.ebenezer.test.Customers.{NewCustomer, OldCustomer}
 import au.com.cba.omnia.ebenezer.test.NestedCustomers.NestedA
 import au.com.cba.omnia.ebenezer.test.WideUnion._

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "0.22.4"
+version in ThisBuild := "0.23.0"
 
 localVersionSettings
 


### PR DESCRIPTION
We have a use case where we want to have an unpartitioned sink, but do not want to write the _SUCCESS flag, as that is written later once metadata is written to the same sink. This adds a commit option to ParquetScroogeSource.

This replaces https://github.com/CommBank/ebenezer/pull/153