### PR TITLE
updating beeswax version

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -30,7 +30,7 @@ object build extends Build {
   val thermometerVersion   = "1.4.6-20161026213817-fb25e67"
   val omnitoolVersion      = "1.14.2-20161028030316-93de570"
   val humbugVersion        = "0.7.3-20161026213926-d09fb4b"
-  val beeswaxVersion       = "0.1.3-20161030222527-5304197"
+  val beeswaxVersion       = "0.1.4-20161206003704-097a0d1"
 
   lazy val standardSettings =
     Defaults.coreDefaultSettings ++

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "0.23.2"
+version in ThisBuild := "0.23.3"
 
 localVersionSettings
 


### PR DESCRIPTION
Beeswax is now updated to support data types like nested structs. We would like to use this capability of beeswax while using Ebenezer (& maestro).

Change summary:
1) Updated beeswax 
2) Version bump