### PR TITLE
Document apparent ScroogeReadSupport requirement

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ScroogeReadSupport.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ScroogeReadSupport.scala
@@ -44,6 +44,10 @@ class ScroogeReadSupport[A <: ThriftStruct] extends ReadSupport[A] {
 object ScroogeReadSupport {
   val thriftClass = "parquet.scrooge.read.class";
 
+  /** Configure a [[JobConf]] to use Scrooge to read Parquet.
+   *
+   * Note: This must be done before instantiating the [[Job]] object.
+   */
   def setAsParquetSupportClass[A <: ThriftStruct : Manifest](conf: JobConf) {
     ParquetInputFormat.setReadSupportClass(conf, classOf[ScroogeReadSupport[_]])
     ScroogeReadWriteSupport.setThriftClass[A](conf, thriftClass)


### PR DESCRIPTION
It seems (after quite a bit of annoying debugging of a problem after an obviously safe refactoring in Hydro) that `ScroogeReadSupport.setAsParquetSupportClass` must be called *before* instantiating `Job`. Calling it after instantiating `Job` resulted in NPE errors.

Presumably this is the case for the Write and ReadWrite helpers too?