### PR TITLE
CDH 5.13.0

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ScroogeWriteSupport.scala
+++ b/core/src/main/scala/au/com/cba/omnia/ebenezer/scrooge/ScroogeWriteSupport.scala
@@ -42,7 +42,7 @@ class ScroogeWriteSupport[A <: ThriftStruct] extends WriteSupport[A] {
     val thrift = ScroogeReadWriteSupport.getThriftClass[A](config, ScroogeWriteSupport.thriftClass)
     val converter = new ScroogeStructConverter
     struct = converter.convert(thrift)
-    schema =  new ThriftSchemaConverter().convert(struct)
+    schema =  ThriftSchemaConverter.convertWithoutProjection(struct)
     val extra = new java.util.HashMap[String, String]
     extra.put("thrift.class", thrift.getName)
     extra.put("thrift.descriptor", struct.toJSON)

--- a/project/build.scala
+++ b/project/build.scala
@@ -27,10 +27,10 @@ import au.com.cba.omnia.uniform.assembly.UniformAssemblyPlugin._
 import au.com.cba.omnia.humbug.HumbugSBT._
 
 object build extends Build {
-  val thermometerVersion   = "1.5.10-20170501023059-67accaf"
-  val omnitoolVersion      = "1.14.9-20170710003444-8f25fcd"
-  val humbugVersion        = "0.7.8-20170501020334-64f8587"
-  val beeswaxVersion       = "0.1.15-20170710010323-278c3d1"
+  val thermometerVersion   = "1.6.0-20180124000127-aec09bd-cdh-513"
+  val omnitoolVersion      = "1.15.0-20180124002420-8583973-cdh-513"
+  val humbugVersion        = "0.8.0-20180124005627-cf7d6c4-cdh-513"
+  val beeswaxVersion       = "0.2.0-20180124040559-79287a6-cdh-513"
 
   lazy val standardSettings =
     Defaults.coreDefaultSettings ++

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ resolvers ++= Seq(
   "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/"
 )
 
-val uniformVersion = "1.15.1-20170426071414-6d891a6"
+val uniformVersion = "1.16.1-20180124040232-e0aaf4c-cdh-513"
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)
 
@@ -28,4 +28,4 @@ addSbtPlugin("au.com.cba.omnia" % "uniform-thrift"     % uniformVersion)
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-assembly"   % uniformVersion)
 
-addSbtPlugin("au.com.cba.omnia" % "humbug-plugin"      % "0.7.8-20170501020334-64f8587")
+addSbtPlugin("au.com.cba.omnia" % "humbug-plugin"      % "0.8.0-20180124005627-cf7d6c4-cdh-513")

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "0.23.13"
+version in ThisBuild := "0.24.0"
 
 localVersionSettings
 


### PR DESCRIPTION
Driven by [Uniform PR #103](https://github.com/CommBank/uniform/pull/103) .

Upgrades libraries to CDH 5.13.0, as per:
 - https://archive.cloudera.com/cdh5/cdh/5/hadoop/hadoop-project-dist/hadoop-common/dependency-analysis.html
 - https://www.cloudera.com/documentation/enterprise/release-notes/topics/cm_vd_cdh_package_tarball_513.html